### PR TITLE
Return default value if the stack is empty

### DIFF
--- a/EnumerableDropOutStack.cs
+++ b/EnumerableDropOutStack.cs
@@ -53,6 +53,9 @@ namespace EnumerableDropOutStack
         /// <returns>T.</returns>
         public T Pop()
         {
+			if (Count() < 0)
+                return default(T);
+			
             _count -= 1;
             _count = _count < 0 ? 0 : _count;
 
@@ -66,6 +69,9 @@ namespace EnumerableDropOutStack
         /// <returns>T.</returns>
         public T Peek()
         {
+			if (Count() < 0)
+                return default(T);
+			
             return _items[(_items.Length + _top - 1) % _items.Length]; //Same as pop but without changing the value of top.
         }
 

--- a/EnumerableDropOutStack.cs
+++ b/EnumerableDropOutStack.cs
@@ -53,7 +53,7 @@ namespace EnumerableDropOutStack
         /// <returns>T.</returns>
         public T Pop()
         {
-			if (Count() < 0)
+            if (Count() < 0)
                 return default(T);
 			
             _count -= 1;
@@ -69,7 +69,7 @@ namespace EnumerableDropOutStack
         /// <returns>T.</returns>
         public T Peek()
         {
-			if (Count() < 0)
+            if (Count() < 0)
                 return default(T);
 			
             return _items[(_items.Length + _top - 1) % _items.Length]; //Same as pop but without changing the value of top.

--- a/EnumerableDropOutStack.cs
+++ b/EnumerableDropOutStack.cs
@@ -53,7 +53,7 @@ namespace EnumerableDropOutStack
         /// <returns>T.</returns>
         public T Pop()
         {
-            if (Count() < 0)
+            if (Count() <= 0)
                 return default(T);
 			
             _count -= 1;
@@ -69,7 +69,7 @@ namespace EnumerableDropOutStack
         /// <returns>T.</returns>
         public T Peek()
         {
-            if (Count() < 0)
+            if (Count() <= 0)
                 return default(T);
 			
             return _items[(_items.Length + _top - 1) % _items.Length]; //Same as pop but without changing the value of top.


### PR DESCRIPTION
Before this PR, if the stack had existing items which were removed using `Clear()`, the `Peek()` and `Pop()` methods would return a random item that was previously removed. This PR introduces a check to ensure the stack is not empty. If it is empty, the default value is returned.